### PR TITLE
Filtro para as traduções incompletas + bug-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-
 # Dev Prothera
 
-Auxilia no desenvolvimento do projeto prothera com a listagem de ícones svg e manutenção do arquivo de traduções.
-
-
+Projeto criado para auxiliar o desenvolvimento do software da empresa Prothera Tecnologias LTDA, com a listagem de ícones svg e manutenção do arquivo de traduções via plugin i18n de maneira dinâmica.
 
 ## Funcionalidades
 
@@ -20,15 +17,15 @@ Auxilia no desenvolvimento do projeto prothera com a listagem de ícones svg e m
 
 ## Como utilizar
 
-Crie um arquivo .env seguindo o modelo (.env.example) 
+Crie um arquivo .env seguindo o modelo (.env.example)
 indicando o caminho do diretório de ícones e do arquivo de traduções.
 
 Execute o comando na raiz do projeto:
+
 ```bash
 npm install
 npm start
 ```
-
 
 ## Documentação da API
 
@@ -37,6 +34,7 @@ npm start
 ```http
   GET /api/icones
 ```
+
 ```
 Response: [ { svg: <NODE_HTML>, nomeArquivo: 'icone' }, ... ]
 ```
@@ -46,24 +44,27 @@ Response: [ { svg: <NODE_HTML>, nomeArquivo: 'icone' }, ... ]
 ```http
   GET /api/traducoes
 ```
+
 ```
 Response: { pt: { olaMundo: 'Olá mundo', }, ... }
 ```
 
 #### Salva todas as alterações no arquivo
+
 ```http
   POST /api/traducoes
 ```
+
 ```
 Request: [ {id: 'olaMundo', chave: 'olaMundo', pt: 'Olá Mundo', en: 'Hello World', es: 'Hola Mundo', status: 'adicionar' }, ... ]
 ```
-| Parâmetro   | Tipo       | Descrição                                   |
-| :---------- | :--------- | :------------------------------------------ |
-| `id`      | `string` | O ID da tradução é a chave original que indica a mensagem no arquivo de traduções  |
-| `chave`   | `string` | A chave pode ser uma nova ou a mesma que o ID |
-| `pt`      | `string` | A nova mensagem em português |
-| `en`      | `string` | A nova mensagem em inglês |
-| `es`      | `string` | A nova mensagem em espanhol |
-| `status`      | `'excluido' \| 'adicionado' \| 'editado'` | Indicação de alteração da mensagem |
 
+| Parâmetro | Tipo                                      | Descrição                                                                         |
+| :-------- | :---------------------------------------- | :-------------------------------------------------------------------------------- |
+| `id`      | `string`                                  | O ID da tradução é a chave original que indica a mensagem no arquivo de traduções |
+| `chave`   | `string`                                  | A chave pode ser uma nova ou a mesma que o ID                                     |
+| `pt`      | `string`                                  | A nova mensagem em português                                                      |
+| `en`      | `string`                                  | A nova mensagem em inglês                                                         |
+| `es`      | `string`                                  | A nova mensagem em espanhol                                                       |
+| `status`  | `'excluido' \| 'adicionado' \| 'editado'` | Indicação de alteração da mensagem                                                |
 

--- a/public/js/statusTraducaoENUM.js
+++ b/public/js/statusTraducaoENUM.js
@@ -1,7 +1,7 @@
 const StatusTraducaoEnum = Object.freeze({
-  ADICIONADO : 'adicionado',
-  EXCLUIDO : 'excluido',
-  EDITADO: 'editado',
+  ADICIONADO : 'Adicionado',
+  EXCLUIDO : 'Excluido',
+  EDITADO: 'Editado',
 });
 
 export default StatusTraducaoEnum;

--- a/public/js/statusTraducaoENUM.js
+++ b/public/js/statusTraducaoENUM.js
@@ -2,6 +2,8 @@ const StatusTraducaoEnum = Object.freeze({
   ADICIONADO : 'Adicionado',
   EXCLUIDO : 'Excluido',
   EDITADO: 'Editado',
+  INCOMPLETO: 'Incompleto',
+  COMPLETO: 'Completo',
 });
 
 export default StatusTraducaoEnum;

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -22,10 +22,19 @@ function clonarObjeto (objeto) {
   return JSON.parse(JSON.stringify(objeto));
 }
 
+function verificaTraducaoIncompleta(traducao) {
+  if(!traducao.pt.length || !traducao.en.length || !traducao.es.length){
+    return true;
+  }
+
+  return false;
+}
+
 export {
   parseData,
   primeiraLetraMaiuscula,
   primeiraLetraMinuscula,
   removerAcentos,
-  clonarObjeto
+  clonarObjeto,
+  verificaTraducaoIncompleta
 }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,6 @@ app.use(express.static(path.join(dirname(''), "views")));
 
 app.use(router);
 
-app.listen(3000, () => {
-  console.log("server started on http://localhost:3000");
+app.listen(3030, () => {
+  console.log("server started on http://localhost:3030");
 });

--- a/views/components/ModalTraducao.html
+++ b/views/components/ModalTraducao.html
@@ -3,7 +3,10 @@
   v-model:visible="exibir" 
   :breakpoints="{'960px': '75vw', '640px': '90vw'}"
   :style="{width: '50vw'}" 
-  :maximizable="true" :modal="true">
+  :closable="false"
+  :maximizable="true"
+  :modal="true"
+>
   <form id="formularioNovaTraducao">
     <div class="field mb-3">
       <label for="inputChave">Chave<span class="text-danger">*</span></label>
@@ -29,3 +32,9 @@
     <p-button type="submit" label="Inserir" icon="pi pi-check" @click="salvar" autofocus></p-button>
   </template>
 </p-dialog>
+
+<style scoped>
+  .p-dialog-header-close {
+    display: none;
+  }
+</style>

--- a/views/components/ModalTraducao.js
+++ b/views/components/ModalTraducao.js
@@ -25,7 +25,10 @@ const ModalTraducao = async () => {
     },
     methods: {
       salvar () {
-        if (!(this.chave && this.pt)) return;
+        if (!(this.chave && this.pt)){
+          return;
+        } 
+        
         this.$emit('salvar', {
           id: this.traducao?.id,
           chave: this.chave,

--- a/views/pages/Traducoes.html
+++ b/views/pages/Traducoes.html
@@ -12,7 +12,7 @@
     option-label="name" 
     placeholder="Filtrar por status" 
     class="mb-4"
-    display="chip"></p-multiselect>
+    display="chip" />
   
   <Tabela 
     :colunas="tabela.colunas" 

--- a/views/pages/Traducoes.js
+++ b/views/pages/Traducoes.js
@@ -1,5 +1,5 @@
 import StatusTraducaoEnum from '/js/statusTraducaoENUM.js';
-import { clonarObjeto } from '/js/utils.js';
+import { clonarObjeto, verificaTraducaoIncompleta } from '/js/utils.js';
 import ModalTraducao from '/components/ModalTraducao.js';
 import Tabela from '/components/Tabela.js';
 const { useToast } = primevue.usetoast;
@@ -23,7 +23,8 @@ const Traducoes = async () => {
         status: [
           { name: StatusTraducaoEnum.ADICIONADO, code: StatusTraducaoEnum.ADICIONADO },
           { name: StatusTraducaoEnum.EXCLUIDO, code: StatusTraducaoEnum.EXCLUIDO },
-          { name: StatusTraducaoEnum.EDITADO, code: StatusTraducaoEnum.EDITADO }
+          { name: StatusTraducaoEnum.EDITADO, code: StatusTraducaoEnum.EDITADO },
+          { name: StatusTraducaoEnum.INCOMPLETO, code: StatusTraducaoEnum.INCOMPLETO }
         ],
         statusSelecionados: [],
         toast: useToast(),
@@ -46,6 +47,10 @@ const Traducoes = async () => {
       itensTabela () {
         const arrayFiltroStatus = this.statusSelecionados.map(status => status.code);
 
+        console.log('teste adicionados: ', this.tabela.itens.filter(traducao => {
+          return arrayFiltroStatus.length ? arrayFiltroStatus.includes(traducao.status) : traducao;
+        }))
+
         return this.tabela.itens.filter(traducao => {
           return arrayFiltroStatus.length ? arrayFiltroStatus.includes(traducao.status) : traducao;
         });
@@ -53,6 +58,7 @@ const Traducoes = async () => {
     },
     async mounted () {
       const traducoes = await this.buscarTraducoes();
+
       for (const chave in traducoes?.pt) {
         const linhaTraducao = {
           id: chave,
@@ -61,8 +67,16 @@ const Traducoes = async () => {
           es: traducoes.es[chave] || '',
           en: traducoes.en[chave] || '',
         }
+         
+        linhaTraducao.status = verificaTraducaoIncompleta(linhaTraducao) ?
+        StatusTraducaoEnum.INCOMPLETO : StatusTraducaoEnum.COMPLETO;
+        
         this.tabela.itens.push(clonarObjeto(linhaTraducao));
       }
+
+      const traducoesIncompletas = this.tabela.itens.filter(traducao => !traducao.pt.length || !traducao.en.length || !traducao.es.length);
+
+      console.log('traducoes incompletas: ', traducoesIncompletas);
       this.traducoesOriginais = clonarObjeto(this.tabela.itens);
     },
     methods: {

--- a/views/pages/Traducoes.js
+++ b/views/pages/Traducoes.js
@@ -19,7 +19,6 @@ const Traducoes = async () => {
     },
     data () {
       return {
-        traducoesOriginais: [],
         exibirModalTraducao: false,
         status: [
           { name: StatusTraducaoEnum.ADICIONADO, code: StatusTraducaoEnum.ADICIONADO },
@@ -46,6 +45,7 @@ const Traducoes = async () => {
       },
       itensTabela () {
         const arrayFiltroStatus = this.statusSelecionados.map(status => status.code);
+
         return this.tabela.itens.filter(traducao => {
           return arrayFiltroStatus.length ? arrayFiltroStatus.includes(traducao.status) : traducao;
         });


### PR DESCRIPTION
Foi adicionado um filtro para trazer da lista de traduções aquelas que estão incompletas, isto é, aquelas que possuem ao menos uma das chaves não preenchidas.

Além disso, foi feito uma pequena correção para esconder o botão de fechar que estava duplicado no modal de adicionar tradução.